### PR TITLE
only check if stdout is a tty

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -19,10 +19,11 @@ var Date = global.Date
   , clearInterval = global.clearInterval;
 
 /**
- * Check if both stdio streams are associated with a tty.
+ * Check if both stdout is associated with a tty. Ignore stderr
+ * because it may have been redirected.
  */
 
-var isatty = tty.isatty(1) && tty.isatty(2);
+var isatty = tty.isatty(1);
 
 /**
  * Expose `Base`.


### PR DESCRIPTION
The reporters are writing to stdout, so there's little reason to
disable tty mode in the event that stderr has been redirected to
/dev/null. This allows noisy tests to be squelched, letting the
reporter output take centre stage.

This allows me to do `npm test 2> /dev/null` without it throwing off the line resetting/deleting.