### PR TITLE
Add check to see if we really are in node even if document exists

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -643,7 +643,7 @@ exports.getError = function(err) {
 
 exports.stackTraceFilter = function() {
   var slash = '/'
-    , is = typeof document === 'undefined'
+    , is = (typeof document === 'undefined' || /(node|iojs)/.test(((process || {}).release || {}).name))
       ? { node: true }
       : { browser: true }
     , cwd = is.node

--- a/test/is-node.js
+++ b/test/is-node.js
@@ -1,0 +1,92 @@
+var tap = require('tap')
+var fs = require('fs')
+var path = require('path')
+var spawn = require('child_process').spawn
+
+var test = tap.test
+
+test('Should successfully report an error', function(t){
+    var testOut = ''
+    var expected = '\ntest/error.js\n\r  1) test/error.js\n\n  0 passing (169.786ms)\n  1 failing\n\n  1) test/error.js test/error.js:\n     test/error.js\n  \n\n'
+
+    // Create a child process for tap-mocha-reporter
+    var cp = spawn(
+        process.argv0,
+        [
+            require.resolve('../'), 'spec'
+        ],
+        {
+            stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+            env: {
+                // pretend to be a Continuous Integration server to disable colors
+                // in the output string for easier comparison / reporting
+                CI: 'testing'
+            }
+        }
+    )
+
+    // pipe TAP output containing an error
+    fs.createReadStream(path.join(__dirname, 'support', 'error.tap'))
+        .pipe(cp.stdin)
+
+    cp.stderr
+        .on('data', function(data){
+            console.error(data.toString())
+        })
+
+    cp.stdout
+        .on('error', function(err){
+            t.fail('Error while reading error.tap', err)
+            cp.kill()
+        })
+        .on('data', function(data){
+            testOut += data
+        })
+        .on('end', function(){
+            t.equal(testOut, expected, 'Reported the error as expected')
+            t.end()
+        })
+})
+
+test('Should successfully report an error when running in node and global `document` is a mock', function(t){
+    var testOut = ''
+    var expected = '\ntest/error.js\n\r  1) test/error.js\n\n  0 passing (169.786ms)\n  1 failing\n\n  1) test/error.js test/error.js:\n     test/error.js\n  \n\n'
+    
+    // Create a child process for tap-mocha-reporter
+    var cp = spawn(
+        process.argv0,
+        [
+            '-r', require.resolve('./support/global-document.js'),
+            require.resolve('../'), 'spec'
+        ],
+        {
+            stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+            env: {
+                // pretend to be a Continuous Integration server to disable colors
+                // in the output string for easier comparison / reporting
+                CI: 'testing'
+            }
+        }
+    )
+
+    // pipe TAP output containing an error
+    fs.createReadStream(path.join(__dirname, 'support', 'error.tap'))
+        .pipe(cp.stdin)
+
+    cp.stderr
+        .on('data', function(data){
+            console.error(data.toString())
+        })
+
+    cp.stdout
+        .on('error', function(err){
+            console.error(err);
+        })
+        .on('data', function(data){
+            testOut += data
+        })
+        .on('end', function(){
+            t.equal(testOut, expected, 'Reported the error as expected')
+            t.end()
+        })
+})

--- a/test/support/error.tap
+++ b/test/support/error.tap
@@ -1,0 +1,24 @@
+TAP version 13
+    # Subtest: test/error.js
+    1..0
+not ok 1 - test/error.js # time=155.087ms
+  ---
+  timeout: 30000
+  file: test/error.js
+  results:
+    ok: false
+    count: 0
+    pass: 0
+    plan:
+      start: 1
+      end: 0
+      skipAll: true
+  exitCode: 1
+  command: /Users/aaron.madsen/.node/bin/node
+  arguments:
+    - test/error.js
+  ...
+
+1..1
+# failed 1 of 1 tests
+# time=169.786ms

--- a/test/support/global-document.js
+++ b/test/support/global-document.js
@@ -1,0 +1,1 @@
+global.document = {}


### PR DESCRIPTION
This fixes an issue where `document` has been mocked in a node environment, but many other interfaces provided by a browser have not that causes `tap-mocha-reporter` to throw a RefferenceError instead of properly reporting an error documented in the TAP stream. It also adds a couple of tests and a few files to support those tests.