### PR TITLE
Proposal: 3rd party formatters

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 module.exports = Formatter
 
 var util = require('util')
+var assert = require('assert')
+var AssertionError = assert.AssertionError
 var reporters = require('./lib/reporters/index.js')
 Formatter.types = Object.keys(reporters).sort()
 var Writable = require('stream').Writable
@@ -29,8 +31,13 @@ function Formatter (type, options) {
     try {
       //Attempt to load 3rd party formatter.
       reporters[type] = require(type)
+      assert(reporters[type] instanceof Function, 'Reporter ' + type + ' was not a function.')
     } catch (e) {
-      console.error('Unknown format type: %s\n\n%s', type, avail())
+      if (e instanceof AssertionError) {
+        console.error('Failed to load ' + type + ': ' + e.message)
+      } else {
+        console.error('Unknown format type: %s\n\n%s', type, avail())
+      }
       type = 'silent'
     }
   }

--- a/index.js
+++ b/index.js
@@ -26,8 +26,13 @@ function Formatter (type, options) {
     return new Formatter(type, options)
   }
   if (!reporters[type]) {
-    console.error('Unknown format type: %s\n\n%s', type, avail())
-    type = 'silent'
+    try {
+      //Attempt to load 3rd party formatter.
+      reporters[type] = require(type)
+    } catch (e) {
+      console.error('Unknown format type: %s\n\n%s', type, avail())
+      type = 'silent'
+    }
   }
 
   this.writable = true

--- a/test/reporter-loading.js
+++ b/test/reporter-loading.js
@@ -1,0 +1,15 @@
+const TSR = require('../index.js')
+const tap = require('tap')
+
+let restoreConsoleError = console.error
+const UKNWN_TYPE = 'unknown'
+
+//Error messaging for unknown reporter types.
+console.error = function(msg, type, avail) {
+  tap.equal(type, UKNWN_TYPE, 'was not passed reporter type.')
+  tap.equal(msg, 'Unknown format type: %s\n\n%s')
+}
+
+TSR(UKNWN_TYPE)
+
+console.error = restoreConsoleError

--- a/test/reporter-loading.js
+++ b/test/reporter-loading.js
@@ -1,15 +1,32 @@
-const TSR = require('../index.js')
-const tap = require('tap')
+var TSR = require('../index.js')
+var tap = require('tap')
 
-let restoreConsoleError = console.error
-const UKNWN_TYPE = 'unknown'
+var restoreConsoleError = console.error
+var UKNWN_TYPE = 'unknown'
 
 //Error messaging for unknown reporter types.
-console.error = function(msg, type, avail) {
-  tap.equal(type, UKNWN_TYPE, 'was not passed reporter type.')
-  tap.equal(msg, 'Unknown format type: %s\n\n%s')
+console.error = function(msg, type, vail) {
+  tap.equal(type, UKNWN_TYPE, 'reporter type should be "unknown".')
+  tap.equal(msg, 'Unknown format type: %s\n\n%s', 'should have correct error msg' )
 }
 
 TSR(UKNWN_TYPE)
 
+//Load from an improperly exported reporter.
+console.error = function(msg) {
+  var modPath = './test/stubs/bad-reporter'
+  var expected = 'Failed to load ' + modPath + ': Reporter ' + modPath + ' was not a function.'
+  tap.equal(actual, expected, 'should have helpful error for bad reporters.')
+}
+
+//Load from a module that exists. 
+
+console.error = function() {
+  tap.fail('needs a different error message')
+}
+
+var reporter = TSR('./lib/reporters/silent')
+
+tap.pass('able to require reporter from module path')
 console.error = restoreConsoleError
+

--- a/test/stubs/bad-reporter.js
+++ b/test/stubs/bad-reporter.js
@@ -1,0 +1,6 @@
+/**
+ * @file a bad reporter.
+ * Reporter modules are supposed to 
+ * be functions.
+ */
+module.exports = {}


### PR DESCRIPTION
The `tap-mocha-reporter` exposes a more convenient interface for certain use cases than the `tap-parser`. It would be nice to be able to create 3rd party reporters to use with `tap-mocha-reporter`.

This is just a cheap trick that I've created to work around my issue, but it would be nice to formalize a system for 3rd party formatters.

### Issues

1. Can't load project local node_modules without adding it via `NODE_PATH`.
