### PR TITLE
reporters/json*: Add results to clean()

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -461,3 +461,40 @@ function sameType(a, b) {
   b = Object.prototype.toString.call(b);
   return a == b;
 }
+
+/**
+ * Extract own properties from an Object.
+ * @param {Object} obj
+ * @return {Object}
+ */
+
+function ownProperties(obj) {
+  var res = {};
+  Object.getOwnPropertyNames(obj).forEach(function(key) {
+    res[key] = obj[key];
+  }, obj);
+  return res;
+}
+
+/**
+ * Return a plain-object representation of `test`
+ * free of cyclic properties etc.
+ *
+ * @param {Object} test
+ * @return {Object}
+ * @api private
+ */
+
+var clean = exports.clean = function(test) {
+  var data = {
+    title: test.title,
+    fullTitle: test.fullTitle(),
+    duration: test.duration,
+    err: ownProperties(test.err || {}),
+    result: ownProperties(test.result || {})
+  };
+  if (data.result.name !== undefined) {
+    delete data.result.name;  // already covered by data.title
+  }
+  return data;
+}

--- a/lib/reporters/json-stream.js
+++ b/lib/reporters/json-stream.js
@@ -3,6 +3,7 @@
  */
 
 var Base = require('./base')
+  , clean = Base.clean
   , color = Base.color;
 
 /**
@@ -35,28 +36,10 @@ function List(runner) {
 
   runner.on('fail', function(test, err){
     test = clean(test);
-    test.err = err.message;
     console.log(JSON.stringify(['fail', test]));
   });
 
   runner.on('end', function(){
     process.stdout.write(JSON.stringify(['end', self.stats]));
   });
-}
-
-/**
- * Return a plain-object representation of `test`
- * free of cyclic properties etc.
- *
- * @param {Object} test
- * @return {Object}
- * @api private
- */
-
-function clean(test) {
-  return {
-      title: test.title
-    , fullTitle: test.fullTitle()
-    , duration: test.duration
-  }
 }

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -3,6 +3,7 @@
  */
 
 var Base = require('./base')
+  , clean = Base.clean
   , cursor = Base.cursor
   , color = Base.color;
 
@@ -57,36 +58,4 @@ function JSONReporter(runner) {
 
     process.stdout.write(JSON.stringify(obj, null, 2));
   });
-}
-
-/**
- * Return a plain-object representation of `test`
- * free of cyclic properties etc.
- *
- * @param {Object} test
- * @return {Object}
- * @api private
- */
-
-function clean(test) {
-  return {
-    title: test.title,
-    fullTitle: test.fullTitle(),
-    duration: test.duration,
-    err: errorJSON(test.err || {})
-  }
-}
-
-/**
- * Transform `error` into a JSON object.
- * @param {Error} err
- * @return {Object}
- */
-
-function errorJSON(err) {
-  var res = {};
-  Object.getOwnPropertyNames(err).forEach(function(key) {
-    res[key] = err[key];
-  }, err);
-  return res;
 }


### PR DESCRIPTION
This exposes important information like diagnostic output.

Also move the test-cleaning function into `base.js` where it can be used by both `json.js` and `json-stream.js`.