### PR TITLE
index.js: Configurable reporter options for Formatter

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,9 +21,9 @@ var Parser = require('tap-parser')
 util.inherits(Formatter, Writable)
 
 var exitCode
-function Formatter (type, options) {
+function Formatter (type, runnerOptions, options) {
   if (!(this instanceof Formatter)) {
-    return new Formatter(type, options)
+    return new Formatter(type, runnerOptions, options)
   }
   if (!reporters[type]) {
     console.error('Unknown format type: %s\n\n%s', type, avail())
@@ -49,9 +49,12 @@ function Formatter (type, options) {
     return this
   }
 
-  var runner = this.runner = new Runner(options)
-  this.reporter = new reporters[type](this.runner, {})
-  Writable.call(this, options)
+  var runner = this.runner = new Runner(runnerOptions)
+  this.reporter = new reporters[type](
+    this.runner,
+    (options || {}).reporter || {},
+  )
+  Writable.call(this, runnerOptions)
 
   runner.on('end', function () {
     if (!runner.parser.ok)


### PR DESCRIPTION
06efe962 (Fix xunit reporter, 2015-04-25) added a hard-coded empty object for the reporter options.  This commit allows the user to override that with their own config, falling back to an empty object if the given value is falsy (for backwards compat with existing `Formatter(...)` callers).

If `Formatter` wasn't already taking a runtime-options argument, I would have preferred:

```javascript
function Formatter (type, options) {
  // ...
  var runner = this.runner = new Runner((options || {}).runner)
  this.reporter = new reporters[type](
    this.runner,
    (options || {}).reporter || {},
  )
  Writable.call(this, (options || {}).runner)
  // ...
}
```

but we can't add `runner` namespacing to the existing options argument without breaking backwards compat or adding brittle heuristic translation.  So I'm just adding a new option, where the reporter is namespaced to allow for other configurable aspects to also use the new argument (if we grow other configurable aspects in the future).