### PR TITLE
Use a version of debug that doesn't trigger an npm audit warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -358,11 +358,11 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "delayed-stream": {
@@ -779,9 +779,9 @@
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "nyc": {
       "version": "13.3.0",
@@ -2125,6 +2125,21 @@
         "unicode-length": "^1.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "tap-parser": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
@@ -2154,7 +2169,7 @@
       "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-0.0.1.tgz",
       "integrity": "sha512-kESEC7r7z6mPerY37gSd5GbIkUgkMNknnVn90/iFqr0vKO6fg7k+GMq7KRqhBGVY1zeA6ajni1mEsI38Z2dU7w==",
       "requires": {
-        "yaml": "github:isaacs/yaml#built"
+        "yaml": "github:isaacs/yaml#4c57d8e6dc082872654d237be4fd823e1c9457e0"
       }
     },
     "tmatch": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/isaacs/tap-mocha-reporter",
   "dependencies": {
     "color-support": "^1.1.0",
-    "debug": "^2.1.3",
+    "debug": "^3.1.0",
     "diff": "^1.3.2",
     "escape-string-regexp": "^1.0.3",
     "glob": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-mocha-reporter",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Format a TAP stream using Mocha's set of reporters",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Changing package.json to use debug ^3.1.0. This clears the security warnings in tap-mocha-reporter.
This change is preceding changes I have queued up in a fork of node-tap to clear out security warnings there associated with release 10.7.3. I will submit a pull request there if/when this one is accepted.

Tests passed on my local host for:
lts/boron
lts/carbon
lts/dubnium
v11.10.0

lts/argon failed, not sure if this matters to you.

Thanks for your consideration.
