### PR TITLE
use setPrototypeOf instead of __proto__

### DIFF
--- a/lib/reporters/dot.js
+++ b/lib/reporters/dot.js
@@ -59,4 +59,4 @@ function Dot(runner) {
  * Inherit from `Base.prototype`.
  */
 
-Dot.prototype.__proto__ = Base.prototype;
+Object.setPrototypeOf(Dot.prototype, Base.prototype);

--- a/lib/reporters/landing.js
+++ b/lib/reporters/landing.js
@@ -93,4 +93,4 @@ function Landing(runner) {
  * Inherit from `Base.prototype`.
  */
 
-Landing.prototype.__proto__ = Base.prototype;
+Object.setPrototypeOf(Landing.prototype, Base.prototype);

--- a/lib/reporters/list.js
+++ b/lib/reporters/list.js
@@ -60,4 +60,4 @@ function List(runner) {
  * Inherit from `Base.prototype`.
  */
 
-List.prototype.__proto__ = Base.prototype;
+Object.setPrototypeOf(List.prototype, Base.prototype);

--- a/lib/reporters/min.js
+++ b/lib/reporters/min.js
@@ -34,4 +34,4 @@ function Min(runner) {
  * Inherit from `Base.prototype`.
  */
 
-Min.prototype.__proto__ = Base.prototype;
+Object.setPrototypeOf(Min.prototype, Base.prototype);

--- a/lib/reporters/nyan.js
+++ b/lib/reporters/nyan.js
@@ -257,4 +257,4 @@ function write(string) {
  * Inherit from `Base.prototype`.
  */
 
-NyanCat.prototype.__proto__ = Base.prototype;
+Object.setPrototypeOf(NyanCat.prototype, Base.prototype);

--- a/lib/reporters/progress.js
+++ b/lib/reporters/progress.js
@@ -89,4 +89,4 @@ function Progress(runner, options) {
  * Inherit from `Base.prototype`.
  */
 
-Progress.prototype.__proto__ = Base.prototype;
+Object.setPrototypeOf(Progress.prototype, Base.prototype);

--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -79,4 +79,4 @@ function Spec(runner) {
  * Inherit from `Base.prototype`.
  */
 
-Spec.prototype.__proto__ = Base.prototype;
+Object.setPrototypeOf(Spec.prototype, Base.prototype);

--- a/lib/reporters/xunit.js
+++ b/lib/reporters/xunit.js
@@ -88,7 +88,7 @@ XUnit.prototype.done = function(failures, fn) {
  * Inherit from `Base.prototype`.
  */
 
-XUnit.prototype.__proto__ = Base.prototype;
+Object.setPrototypeOf(XUnit.prototype, Base.prototype);
 
 /**
  * Write out the given line


### PR DESCRIPTION
This avoids security false positives from things checking for __proto__ usage and __proto__ is optional in the JS spec so it may not exist in all environments