### PR TITLE
Handle error as string

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -296,14 +296,26 @@ function getError (result) {
   }
 
   if (result.diag && result.diag.error) {
-    err = {
-      name: result.diag.error.name || 'Error',
-      message: result.diag.error.message,
-      toString: function () {
-        return this.name + ': ' + this.message
-      },
-      stack: result.diag.error.stack
-    }
+    // see: https://github.com/tapjs/tap-mocha-reporter/issues/72
+    if (typeof result.diag.error === 'string') {
+      err = {
+        name: 'Error',
+        message: result.diag.error,
+        toString: function () {
+            return this.name + ': ' + this.message
+        },
+        stack: result.diag.stack
+      }
+    } else {
+      err = {
+        name: result.diag.error.name || 'Error',
+        message: result.diag.error.message,
+        toString: function () {
+            return this.name + ': ' + this.message
+        },
+        stack: result.diag.error.stack
+        }
+      }
   } else {
     err = {
       message: (result.name || '(unnamed error)').replace(/^Error: /, ''),

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "tap-mocha-reporter": "index.js"
       },
       "devDependencies": {
-        "tap": "^15.1.6"
+        "tap": "^15.2.2"
       },
       "engines": {
         "node": ">= 8"
@@ -1604,9 +1604,9 @@
       }
     },
     "node_modules/libtap": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/libtap/-/libtap-1.1.4.tgz",
-      "integrity": "sha512-jM+QyAeRdVs1bJrNpjlu+l8gRdDkAehqls31AwSnqXghVLUP6nbYeU2Xfs2svYS7ZdksvnHvrxCKRBFEz/BCjA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/libtap/-/libtap-1.2.2.tgz",
+      "integrity": "sha512-GZWH3fipvi6Pgrpy6Bi8unioB3Vu6qQRYQ+h6NxfzwvCm5yut1j4W8AQfX9Yab03CiFGjro55G0SIp6unVdx0g==",
       "dev": true,
       "dependencies": {
         "async-hook-domain": "^2.0.4",
@@ -1618,34 +1618,16 @@
         "own-or-env": "^1.0.2",
         "signal-exit": "^3.0.4",
         "stack-utils": "^2.0.4",
-        "tap-parser": "^10.0.1",
+        "tap-parser": "^11.0.0",
         "tap-yaml": "^1.0.0",
         "tcompare": "^5.0.6",
-        "trivial-deferred": "^1.0.1",
-        "yapool": "^1.0.0"
+        "trivial-deferred": "^1.0.1"
       },
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/libtap/node_modules/tap-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.1.0.tgz",
-      "integrity": "sha512-FujQeciDaOiOvaIVGS1Rpb0v4R6XkOjvWCWowlz5oKuhPkEJ8U6pxgqt38xuzYhPt8dWEnfHn2jqpZdJEkW7pA==",
-      "dev": true,
-      "dependencies": {
-        "events-to-array": "^1.0.1",
-        "minipass": "^3.0.0",
-        "tap-yaml": "^1.0.0"
-      },
-      "bin": {
-        "tap-parser": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/locate-path": {
@@ -2310,9 +2292,9 @@
       }
     },
     "node_modules/tap": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-15.1.6.tgz",
-      "integrity": "sha512-TN7xH6Q2tUPTd6qwmkhuFJcx1vUR8e4dDUpBKc61G0krOzne7Ia6aKIFb8O/0kVazachSSuVME1V8nQ2xwWL8w==",
+      "version": "15.2.2",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-15.2.2.tgz",
+      "integrity": "sha512-MWU8vdFfTAWlVw73bNDgGCzZ6zHFEOprd2eywAsLJLTtr4IKjk4wWG5Qh8x2zJipKA2hEzxANqS2mJ+k2YMBbQ==",
       "bundleDependencies": [
         "ink",
         "treport",
@@ -2334,7 +2316,7 @@
         "isexe": "^2.0.0",
         "istanbul-lib-processinfo": "^2.0.2",
         "jackspeak": "^1.4.1",
-        "libtap": "^1.1.4",
+        "libtap": "^1.2.2",
         "minipass": "^3.1.1",
         "mkdirp": "^1.0.4",
         "nyc": "^15.1.0",
@@ -2343,8 +2325,8 @@
         "rimraf": "^3.0.0",
         "signal-exit": "^3.0.6",
         "source-map-support": "^0.5.16",
-        "tap-mocha-reporter": "^5.0.0",
-        "tap-parser": "^10.0.1",
+        "tap-mocha-reporter": "^5.0.3",
+        "tap-parser": "^11.0.0",
         "tap-yaml": "^1.0.0",
         "tcompare": "^5.0.7",
         "treport": "*",
@@ -2377,9 +2359,9 @@
       }
     },
     "node_modules/tap-mocha-reporter": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-5.0.1.tgz",
-      "integrity": "sha512-1knFWOwd4khx/7uSEnUeaP9IPW3w+sqTgJMhrwah6t46nZ8P25atOKAjSvVDsT67lOPu0nfdOqUwoyKn+3E5pA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-5.0.3.tgz",
+      "integrity": "sha512-6zlGkaV4J+XMRFkN0X+yuw6xHbE9jyCZ3WUKfw4KxMyRGOpYSRuuQTRJyWX88WWuLdVTuFbxzwXhXuS2XE6o0g==",
       "dev": true,
       "dependencies": {
         "color-support": "^1.1.0",
@@ -2387,29 +2369,12 @@
         "diff": "^4.0.1",
         "escape-string-regexp": "^2.0.0",
         "glob": "^7.0.5",
-        "tap-parser": "^10.0.0",
+        "tap-parser": "^11.0.0",
         "tap-yaml": "^1.0.0",
         "unicode-length": "^2.0.2"
       },
       "bin": {
         "tap-mocha-reporter": "index.js"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/tap-mocha-reporter/node_modules/tap-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.1.0.tgz",
-      "integrity": "sha512-FujQeciDaOiOvaIVGS1Rpb0v4R6XkOjvWCWowlz5oKuhPkEJ8U6pxgqt38xuzYhPt8dWEnfHn2jqpZdJEkW7pA==",
-      "dev": true,
-      "dependencies": {
-        "events-to-array": "^1.0.1",
-        "minipass": "^3.0.0",
-        "tap-yaml": "^1.0.0"
-      },
-      "bin": {
-        "tap-parser": "bin/cmd.js"
       },
       "engines": {
         "node": ">= 8"
@@ -3631,7 +3596,7 @@
       "license": "MIT"
     },
     "node_modules/tap/node_modules/minipass": {
-      "version": "3.1.5",
+      "version": "3.1.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4016,13 +3981,13 @@
       }
     },
     "node_modules/tap/node_modules/tap-parser": {
-      "version": "10.1.0",
+      "version": "11.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "events-to-array": "^1.0.1",
-        "minipass": "^3.0.0",
+        "minipass": "^3.1.6",
         "tap-yaml": "^1.0.0"
       },
       "bin": {
@@ -4051,7 +4016,7 @@
       }
     },
     "node_modules/tap/node_modules/treport": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4061,7 +4026,7 @@
         "chalk": "^3.0.0",
         "ink": "^3.2.0",
         "ms": "^2.1.2",
-        "tap-parser": "^10.0.1",
+        "tap-parser": "^11.0.0",
         "unicode-length": "^2.0.2"
       },
       "peerDependencies": {
@@ -4560,12 +4525,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/yapool": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
-      "integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o=",
-      "dev": true
     },
     "node_modules/yargs": {
       "version": "15.4.1",
@@ -5861,9 +5820,9 @@
       "dev": true
     },
     "libtap": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/libtap/-/libtap-1.1.4.tgz",
-      "integrity": "sha512-jM+QyAeRdVs1bJrNpjlu+l8gRdDkAehqls31AwSnqXghVLUP6nbYeU2Xfs2svYS7ZdksvnHvrxCKRBFEz/BCjA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/libtap/-/libtap-1.2.2.tgz",
+      "integrity": "sha512-GZWH3fipvi6Pgrpy6Bi8unioB3Vu6qQRYQ+h6NxfzwvCm5yut1j4W8AQfX9Yab03CiFGjro55G0SIp6unVdx0g==",
       "dev": true,
       "requires": {
         "async-hook-domain": "^2.0.4",
@@ -5875,24 +5834,10 @@
         "own-or-env": "^1.0.2",
         "signal-exit": "^3.0.4",
         "stack-utils": "^2.0.4",
-        "tap-parser": "^10.0.1",
+        "tap-parser": "^11.0.0",
         "tap-yaml": "^1.0.0",
         "tcompare": "^5.0.6",
-        "trivial-deferred": "^1.0.1",
-        "yapool": "^1.0.0"
-      },
-      "dependencies": {
-        "tap-parser": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.1.0.tgz",
-          "integrity": "sha512-FujQeciDaOiOvaIVGS1Rpb0v4R6XkOjvWCWowlz5oKuhPkEJ8U6pxgqt38xuzYhPt8dWEnfHn2jqpZdJEkW7pA==",
-          "dev": true,
-          "requires": {
-            "events-to-array": "^1.0.1",
-            "minipass": "^3.0.0",
-            "tap-yaml": "^1.0.0"
-          }
-        }
+        "trivial-deferred": "^1.0.1"
       }
     },
     "locate-path": {
@@ -6403,9 +6348,9 @@
       }
     },
     "tap": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-15.1.6.tgz",
-      "integrity": "sha512-TN7xH6Q2tUPTd6qwmkhuFJcx1vUR8e4dDUpBKc61G0krOzne7Ia6aKIFb8O/0kVazachSSuVME1V8nQ2xwWL8w==",
+      "version": "15.2.2",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-15.2.2.tgz",
+      "integrity": "sha512-MWU8vdFfTAWlVw73bNDgGCzZ6zHFEOprd2eywAsLJLTtr4IKjk4wWG5Qh8x2zJipKA2hEzxANqS2mJ+k2YMBbQ==",
       "dev": true,
       "requires": {
         "@isaacs/import-jsx": "*",
@@ -6420,7 +6365,7 @@
         "isexe": "^2.0.0",
         "istanbul-lib-processinfo": "^2.0.2",
         "jackspeak": "^1.4.1",
-        "libtap": "^1.1.4",
+        "libtap": "^1.2.2",
         "minipass": "^3.1.1",
         "mkdirp": "^1.0.4",
         "nyc": "^15.1.0",
@@ -6429,8 +6374,8 @@
         "rimraf": "^3.0.0",
         "signal-exit": "^3.0.6",
         "source-map-support": "^0.5.16",
-        "tap-mocha-reporter": "^5.0.0",
-        "tap-parser": "^10.0.1",
+        "tap-mocha-reporter": "^5.0.3",
+        "tap-parser": "^11.0.0",
         "tap-yaml": "^1.0.0",
         "tcompare": "^5.0.7",
         "treport": "*",
@@ -7220,7 +7165,7 @@
           "dev": true
         },
         "minipass": {
-          "version": "3.1.5",
+          "version": "3.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7479,12 +7424,12 @@
           }
         },
         "tap-parser": {
-          "version": "10.1.0",
+          "version": "11.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "events-to-array": "^1.0.1",
-            "minipass": "^3.0.0",
+            "minipass": "^3.1.6",
             "tap-yaml": "^1.0.0"
           }
         },
@@ -7502,7 +7447,7 @@
           "dev": true
         },
         "treport": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7511,7 +7456,7 @@
             "chalk": "^3.0.0",
             "ink": "^3.2.0",
             "ms": "^2.1.2",
-            "tap-parser": "^10.0.1",
+            "tap-parser": "^11.0.0",
             "unicode-length": "^2.0.2"
           },
           "dependencies": {
@@ -7662,9 +7607,9 @@
       }
     },
     "tap-mocha-reporter": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-5.0.1.tgz",
-      "integrity": "sha512-1knFWOwd4khx/7uSEnUeaP9IPW3w+sqTgJMhrwah6t46nZ8P25atOKAjSvVDsT67lOPu0nfdOqUwoyKn+3E5pA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-5.0.3.tgz",
+      "integrity": "sha512-6zlGkaV4J+XMRFkN0X+yuw6xHbE9jyCZ3WUKfw4KxMyRGOpYSRuuQTRJyWX88WWuLdVTuFbxzwXhXuS2XE6o0g==",
       "dev": true,
       "requires": {
         "color-support": "^1.1.0",
@@ -7672,22 +7617,9 @@
         "diff": "^4.0.1",
         "escape-string-regexp": "^2.0.0",
         "glob": "^7.0.5",
-        "tap-parser": "^10.0.0",
+        "tap-parser": "^11.0.0",
         "tap-yaml": "^1.0.0",
         "unicode-length": "^2.0.2"
-      },
-      "dependencies": {
-        "tap-parser": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.1.0.tgz",
-          "integrity": "sha512-FujQeciDaOiOvaIVGS1Rpb0v4R6XkOjvWCWowlz5oKuhPkEJ8U6pxgqt38xuzYhPt8dWEnfHn2jqpZdJEkW7pA==",
-          "dev": true,
-          "requires": {
-            "events-to-array": "^1.0.1",
-            "minipass": "^3.0.0",
-            "tap-yaml": "^1.0.0"
-          }
-        }
       }
     },
     "tap-parser": {
@@ -7923,12 +7855,6 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
-    },
-    "yapool": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
-      "integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o=",
-      "dev": true
     },
     "yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "unicode-length": "^2.0.2"
   },
   "devDependencies": {
-    "tap": "^15.1.6"
+    "tap": "^15.2.2"
   },
   "bin": "index.js",
   "files": [


### PR DESCRIPTION
When `tap-mocha-reporter` is used with [native Node.js test-runner](https://nodejs.org/api/test.html#test-runner) output, it receives parsed test result as follows (note `error` field):
```js
{
  ok: false,
  id: 1,
  name: 'should work',
  diag: {
    duration_ms: 2.382542,
    failureType: 'testCodeFailure',
    error: 'Expected values to be strictly equal:\n\n1 !== 2', // <-- error is string not object!
    code: 'ERR_ASSERTION',
    expected: 2,
    actual: 1,
    operator: 'strictEqual',
    stack: 'TestContext.<anonymous> (file:///Users/vitalets/projects/myproject/test/calc.test.ts:9:10)\n' +
      'Test.runInAsyncScope (node:async_hooks:204:9)\n' +
      'Test.run (node:internal/test_runner/test:543:25)\n' +
      'Test.start (node:internal/test_runner/test:464:17)\n' +
      'test (node:internal/test_runner/harness:129:18)\n' +
      'file:///Users/vitalets/projects/myproject/test/calc.test.ts:5:1\n' +
      'ModuleJob.run (node:internal/modules/esm/module_job:194:25)'
  },
  fullname: '/Users/vitalets/projects/myproject/test/calc.test.ts'
}
```
But reporter expects `error` to be an object not string. That's why output does not contain error message and stack (see #72).
This PR fixes the issue by taking error message and stack from `diag` object directly.