### PR TITLE
fix: stack at handling in getError

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -322,7 +322,7 @@ function getError (result) {
       toString: function () {
         return 'Error: ' + this.message
       },
-      stack: result.diag && (result.diag.stack || result.diag.at)
+      stack: result.diag && (result.diag.stack || (result.diag.at && result.diag.at.file))
     }
   }
 


### PR DESCRIPTION
The `result.diag.at` is supposed to be an object with file/line/etc
properties https://testanything.org/tap-version-14-specification.html.
But it is being used as string in `stack.trim()` at `reviveStack`.
Update the code to use `.file` property on it instead.